### PR TITLE
Drop (SDL) from desktop entry

### DIFF
--- a/pacman.desktop
+++ b/pacman.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Pacman (SDL)
+Name=Pacman
 Comment=Yet another pacman clone in C/C++ and SDL
 Exec=pacman
 Icon=/usr/local/share/pacman/gfx/pacman_desktop.png


### PR DESCRIPTION
Having the name "Pacman (SDL)" is of no interest for end users, it might just confuse them since the package name is Pacman.